### PR TITLE
build: Rename npm package to @zeus-ci/cli

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,5 @@
 store: zeus
 targets:
   - github
-  - npm
+  - name: npm
+    access: public

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "eslint.autoFixOnSave": true
-}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
-  "name": "zeus-ci",
+  "name": "@zeus-ci/cli",
   "version": "0.2.4",
   "description": "CLI for https://zeus.ci",
   "main": "src/index.js",
   "repository": "https://github.com/getsentry/zeus-cli",
   "license": "Apache-2.0",
-  "bin": "src/index.js",
+  "bin": {
+    "zeus": "src/index.js"
+  },
   "scripts": {
     "fix:eslint": "eslint --fix src",
     "fix:prettier": "prettier --write 'src/**/*.js'",


### PR DESCRIPTION
This assumes that most users will interact with the tool as `zeus`:

```
zeus upload --type 'what/ever' my-asset.foo
```

Once released, the old package needs to be deprecated. If the name
clashes with the existing package, we can also delete it since there
are no other packages depending on it, yet.

In the future, we can also publish something like `@zeus-ci/sdk`
to integrate with, for instance, [probot-release](https://github.com/getsentry/probot-release).

Fixes #1