### PR TITLE
feat: Allow to override the artifcat name during upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Options:
   --url          Fully qualified URL to the Zeus server                 [string]
   --token        Token for authorized access to Zeus                    [string]
   -t, --type     Mime type of the file to upload                        [string]
+  -n, --name     Artifact name to use in place of the filename          [string]
   -j, --job      Unique id of the job in CI                             [string]
   -b, --build    Unique id of the build in CI                           [string]
 ```

--- a/src/__mocks__/form-data.js
+++ b/src/__mocks__/form-data.js
@@ -9,8 +9,8 @@ module.exports = class FormData {
     this.data = {};
   }
 
-  append(field, value) {
-    this.data[field] = value;
+  append(field, value, options) {
+    this.data[field] = { value, options };
   }
 
   getHeaders(headers) {

--- a/src/commands/__tests__/__snapshots__/upload.test.js.snap
+++ b/src/commands/__tests__/__snapshots__/upload.test.js.snap
@@ -9,6 +9,7 @@ Array [
         "path": "existing1.json",
       },
       "job": "54321",
+      "name": "renamed.json",
       "type": "application/json",
     },
   ],
@@ -19,6 +20,7 @@ Array [
         "path": "existing2.json",
       },
       "job": "54321",
+      "name": "renamed.json",
       "type": "application/json",
     },
   ],
@@ -33,6 +35,21 @@ Array [
       "path": "existing.json",
     },
     "job": "54321",
+    "name": "renamed.json",
+    "type": "application/json",
+  },
+]
+`;
+
+exports[`upload command uses an empty filename by default 1`] = `
+Array [
+  Object {
+    "build": "12345",
+    "file": Object {
+      "path": "existing.json",
+    },
+    "job": "54321",
+    "name": undefined,
     "type": "application/json",
   },
 ]
@@ -46,6 +63,7 @@ Array [
       "path": "existing.json",
     },
     "job": "54321",
+    "name": undefined,
     "type": "application/json",
   },
 ]
@@ -59,6 +77,7 @@ Array [
       "path": "existing.json",
     },
     "job": "54321",
+    "name": undefined,
     "type": "application/json",
   },
 ]

--- a/src/commands/__tests__/upload.test.js
+++ b/src/commands/__tests__/upload.test.js
@@ -33,6 +33,7 @@ describe('upload command', () => {
       build: '12345',
       job: '54321',
       type: 'application/json',
+      name: 'renamed.json',
     };
 
     expect.assertions(1);
@@ -47,6 +48,7 @@ describe('upload command', () => {
       build: '12345',
       job: '54321',
       type: 'application/json',
+      name: 'renamed.json',
     };
 
     expect.assertions(1);
@@ -61,6 +63,7 @@ describe('upload command', () => {
       build: '12345',
       job: '54321',
       type: 'application/json',
+      name: 'renamed.json',
     };
 
     expect.assertions(1);
@@ -89,6 +92,20 @@ describe('upload command', () => {
     const argv = {
       file: ['existing.json'],
       build: '12345',
+      type: 'application/json',
+    };
+
+    expect.assertions(1);
+    return command.handler(argv).then(() => {
+      expect(Zeus.instance.uploadArtifact.mock.calls[0]).toMatchSnapshot();
+    });
+  });
+
+  test('uses an empty filename by default', () => {
+    const argv = {
+      file: ['existing.json'],
+      build: '12345',
+      job: '54321',
       type: 'application/json',
     };
 

--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -21,7 +21,7 @@ module.exports = {
         alias: 'type',
       })
       .option('n', {
-        description: 'Artiface to use in place of the filename',
+        description: 'Artifact name to use in place of the filename',
         type: 'string',
         alias: 'name',
       })

--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -20,6 +20,11 @@ module.exports = {
         type: 'string',
         alias: 'type',
       })
+      .option('n', {
+        description: 'Artiface to use in place of the filename',
+        type: 'string',
+        alias: 'name',
+      })
       .option('j', {
         description: 'Unique id of the job in CI',
         type: 'string',
@@ -40,6 +45,7 @@ module.exports = {
             build: argv.build || env.buildId,
             job: argv.job || env.jobId,
             file: fs.createReadStream(file),
+            name: argv.name,
             type: argv.type,
           });
 

--- a/src/sdk/__tests__/__snapshots__/client.test.js.snap
+++ b/src/sdk/__tests__/__snapshots__/client.test.js.snap
@@ -6,7 +6,10 @@ Array [
   Object {
     "body": FormData {
       "data": Object {
-        "some": "data",
+        "some": Object {
+          "options": undefined,
+          "value": "data",
+        },
       },
       "options": undefined,
     },
@@ -25,7 +28,10 @@ Array [
   Object {
     "body": FormData {
       "data": Object {
-        "some": "data",
+        "some": Object {
+          "options": undefined,
+          "value": "data",
+        },
       },
       "options": undefined,
     },
@@ -98,7 +104,10 @@ Array [
   Object {
     "body": FormData {
       "data": Object {
-        "file": "FILE_DATA",
+        "file": Object {
+          "options": undefined,
+          "value": "FILE_DATA",
+        },
       },
       "options": undefined,
     },
@@ -121,14 +130,42 @@ exports[`Client uploadArtifact rejects without the file parameter 1`] = `[Error:
 
 exports[`Client uploadArtifact rejects without the job parameter 1`] = `[Error: Missing job identifier]`;
 
+exports[`Client uploadArtifact uploads a file with explicit name 1`] = `
+Array [
+  "https://example.org/hooks/feedbeef/builds/12345/jobs/54321/artifacts",
+  Object {
+    "body": FormData {
+      "data": Object {
+        "file": Object {
+          "options": "renamed.json",
+          "value": "FILE_DATA",
+        },
+      },
+      "options": undefined,
+    },
+    "headers": Object {
+      "Content-Length": "42",
+      "content-type": "multipart/form-data; boundary=---feedface",
+    },
+    "method": "POST",
+  },
+]
+`;
+
 exports[`Client uploadArtifact uploads a file with explicit type 1`] = `
 Array [
   "https://example.org/hooks/feedbeef/builds/12345/jobs/54321/artifacts",
   Object {
     "body": FormData {
       "data": Object {
-        "file": "FILE_DATA",
-        "type": "text/plain",
+        "file": Object {
+          "options": undefined,
+          "value": "FILE_DATA",
+        },
+        "type": Object {
+          "options": undefined,
+          "value": "text/plain",
+        },
       },
       "options": undefined,
     },
@@ -147,7 +184,10 @@ Array [
   Object {
     "body": FormData {
       "data": Object {
-        "file": "FILE_DATA",
+        "file": Object {
+          "options": undefined,
+          "value": "FILE_DATA",
+        },
       },
       "options": undefined,
     },

--- a/src/sdk/__tests__/client.test.js
+++ b/src/sdk/__tests__/client.test.js
@@ -204,6 +204,14 @@ describe('Client', () => {
       });
     });
 
+    test('uploads a file with explicit name', () => {
+      expect.assertions(1);
+      params.name = 'renamed.json';
+      return client.uploadArtifact(params).then(() => {
+        expect(request.mock.calls[0]).toMatchSnapshot();
+      });
+    });
+
     test('accepts ZEUS_HOOK_BASE without trailing slash', () => {
       expect.assertions(1);
       process.env.ZEUS_HOOK_BASE = 'https://example.org/hooks/feedbeef';

--- a/src/sdk/client.js
+++ b/src/sdk/client.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const FormData = require('form-data');
+const util = require('util');
 const URL = require('whatwg-url').URL;
 const request = require('./request');
 
@@ -127,8 +128,13 @@ class Client {
   postForm(path, data) {
     const form = new FormData();
     Object.keys(data).forEach(key => {
-      if (data[key] != null) {
-        form.append(key, data[key]);
+      const value = data[key];
+      if (value != null) {
+        if (util.isArray(value)) {
+          form.append(key, value[0], value[1]);
+        } else {
+          form.append(key, value);
+        }
       }
     });
 
@@ -170,7 +176,7 @@ class Client {
       ).toString();
 
       return this.postForm(url, {
-        file: params.file,
+        file: [params.file, params.name],
         type: params.type,
       });
     } catch (e) {


### PR DESCRIPTION
Adds a new option to change the filename:

```
zeus upload -n "renamed.json" original.json
```

Note that this only makes sense for a single file name. Thinking about adding replace/regex, in future, too.